### PR TITLE
rust-overlay migration + README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ cargo install ghgrab
 pipx install ghgrab
 ```
 
+### Nix 
+To have the latest commit:
+``` bash
+nix build github:ghgrab/ghgrab
+```
+
+To have a specific tagged version:
+``` bash
+nix build "github:ghgrab/ghgrab/<tag>"
+```
+
 ---
 
 ### Quick Start
@@ -116,4 +127,3 @@ If you find a bug, have an idea for a cool new feature, or just want to help out
 ## License
 
 Distributed under the MIT License. It's open, free, and yours to play with. See [LICENSE](LICENSE) for the fine print.
-

--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,45 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1773803479,
+        "narHash": "sha256-GD6i1F2vrSxbsmbS92+8+x3DbHOJ+yrS78Pm4xigW4M=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "f17186f52e82ec5cf40920b58eac63b78692ac7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,10 @@
+# flake.nix
 {
   description = "A simple, pretty terminal tool to search and download files from GitHub";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -10,35 +12,36 @@
     {
       self,
       nixpkgs,
+      rust-overlay,
       flake-utils,
       ...
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+
+        rustToolchain = pkgs.rust-bin.stable.latest.default;
+
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = rustToolchain;
+          rustc = rustToolchain;
+        };
       in
       {
-        packages.default = pkgs.rustPlatform.buildRustPackage rec {
+        packages.default = rustPlatform.buildRustPackage {
           pname = "ghgrab";
-          version = "1.0.1";
+          version = "1.0.2";
 
-          src = pkgs.fetchFromGitHub {
-            owner = "abhixdd";
-            repo = "ghgrab";
-            rev = "v${version}";
-            sha256 = "sha256-hcQU00DjcnHrlie8qsIvvtsyiyuqD9dSiWu1c0mv6fs=";
-          };
+          src = ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+        };
 
-          cargoHash = "sha256-SGcbdpcvK9F3q4x+bMwGdLARMg3ResqS8k0ToMfSBAw=";
-
-          nativeBuildInputs = [ pkgs.pkg-config ];
-
-          buildInputs = [
-            pkgs.openssl
-          ];
-
-          doCheck = false;
+        devShells.default = pkgs.mkShell {
+          buildInputs = [ rustToolchain ];
         };
       }
     );


### PR DESCRIPTION
I update the flake.nix and the README using the rust_overlay. This migration is done to avoid hashes and to have a more freedom in the commit/version to take 