### PR TITLE
feat: Homebrew formula + agent integration docs (Willow)

### DIFF
--- a/Formula/ghgrab.rb
+++ b/Formula/ghgrab.rb
@@ -1,0 +1,48 @@
+class Ghgrab < Formula
+  desc "Browse and download files from Git forges without cloning"
+  homepage "https://github.com/abhixdd/ghgrab"
+  version "2.0.1"
+  license "MIT"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/abhixdd/ghgrab/releases/download/v2.0.1/ghgrab-darwin"
+      sha256 "2a9851e953e4d9181936af479c236d499531d2fc725af572ec8b6fcb7884911f"
+    end
+    on_arm do
+      url "https://github.com/abhixdd/ghgrab/releases/download/v2.0.1/ghgrab-darwin-arm64"
+      sha256 "cc8619f45f5ba315ee89ead484b0df75c905336bfeb23da767f596cb524900d0"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/abhixdd/ghgrab/releases/download/v2.0.1/ghgrab-linux"
+      sha256 "fa96f467f54efb5c1b65d69e950b5c8815c6a19a8eec35e7495e34967fdf34f5"
+    end
+    on_arm do
+      url "https://github.com/abhixdd/ghgrab/releases/download/v2.0.1/ghgrab-linux-arm64"
+      sha256 "8354aa41a5822b6db1ec9fb07e8c9fd70c46548b98109b10f6700b25f1c21e10"
+    end
+  end
+
+  def install
+    if OS.mac?
+      if Hardware::CPU.intel?
+        bin.install "ghgrab-darwin" => "ghgrab"
+      else
+        bin.install "ghgrab-darwin-arm64" => "ghgrab"
+      end
+    elsif Hardware::CPU.intel?
+      bin.install "ghgrab-linux" => "ghgrab"
+    else
+      bin.install "ghgrab-linux-arm64" => "ghgrab"
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/ghgrab agent tree not-a-url 2>&1", 1)
+    assert_match '"ok":false', output
+    assert_match '"api_version":"1"', output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ nix run "github:abhixdd/ghgrab/<tag>"
 yay -S ghgrab-bin   
 ```
 
+### Homebrew
+
+A formula ships in `Formula/ghgrab.rb` (macOS and Linux, Intel and ARM64):
+
+```bash
+brew install --formula Formula/ghgrab.rb
+```
+
+See [docs/installation.md](docs/installation.md). Homebrew core submission: [#52](https://github.com/abhixdd/ghgrab/issues/52).
+
 ---
 
 ### Quick Start

--- a/docs/agent-integrations.md
+++ b/docs/agent-integrations.md
@@ -1,0 +1,97 @@
+# Agent Integrations
+
+The `ghgrab agent` subcommand exposes a stable JSON envelope for non-interactive tooling — CI pipelines, MCP servers, and agent runtimes that need repo files without a full `git clone`.
+
+## JSON envelope
+
+Every `agent` command prints JSON to stdout:
+
+```json
+{
+  "api_version": "1",
+  "ok": true,
+  "command": "download",
+  "data": { "...": "..." }
+}
+```
+
+On failure, `ok` is `false` and `error` contains `code` and `message`.
+
+## Willow 2.0 — SAFE app install
+
+[Willow 2.0](https://github.com/rudi193-cmd/willow-2.0) uses `ghgrab agent download` when installing standalone SAFE apps via MCP `app_install`. It prefers ghgrab over `git clone` because it fetches working-tree files without `.git/` history — faster and smaller for agent sandboxes.
+
+```bash
+ghgrab agent download https://github.com/example/my-safe-app \
+  --repo --out ./apps/my-safe-app --no-folder
+```
+
+Willow invocation (from `sap/sap_mcp.py`):
+
+```python
+cmd = [
+    "ghgrab", "agent", "download", repo_url,
+    "--repo", "--out", str(code_path), "--no-folder",
+]
+# Optional: --token $GITHUB_TOKEN for private repos
+```
+
+When `ghgrab` is not on `PATH`, Willow falls back to `git clone`.
+
+### Why agents use `--repo --no-folder`
+
+| Flag | Effect |
+|------|--------|
+| `--repo` | Download the entire repository tree |
+| `--no-folder` | Write directly into `--out` without an extra repo-named subfolder |
+| `--out` | Target directory (created if needed) |
+
+### Multi-forge support
+
+The TUI and `agent` commands support GitHub, GitLab, Codeberg, Gitea, Forgejo, and compatible self-hosted instances (see [commands.md](commands.md)). Willow's install path uses the same URLs it would pass to `git clone`.
+
+## Other integration patterns
+
+### Cherry-pick context for coding agents
+
+Download only the files an agent needs before analysis:
+
+```bash
+ghgrab agent download https://github.com/org/repo src/lib README.md --out ./context
+```
+
+### CI artifact staging
+
+Use `--token auto` to pick up `gh auth token` without persisting credentials:
+
+```bash
+ghgrab agent download https://github.com/org/private-repo --repo --out ./staging --token auto
+```
+
+### Tree inspection before download
+
+Inspect structure without downloading:
+
+```bash
+ghgrab agent tree https://github.com/rust-lang/rust | jq '.data.entries[:5]'
+```
+
+## Submitting an integration
+
+If your project uses `ghgrab agent` in production, open a PR adding a short section here with:
+
+- Project name and link
+- Command shape (flags matter)
+- Why ghgrab vs `git clone` or the GitHub API
+
+## Homebrew
+
+Install ghgrab on macOS/Linux with the bundled formula (until accepted into Homebrew core):
+
+```bash
+brew install --formula Formula/ghgrab.rb
+# or, after tap setup:
+brew install ghgrab
+```
+
+See [installation.md](installation.md) for npm, cargo, pipx, and nix options.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,6 +84,8 @@ The `agent` command is designed for non-interactive tooling. It prints a stable 
 - `data` on success
 - `error` on failure
 
+See [agent-integrations.md](agent-integrations.md) for production consumers (including [Willow 2.0](https://github.com/rudi193-cmd/willow-2.0) SAFE app install).
+
 ### Fetch a repository tree
 
 ```bash

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Repository browsing and path downloads support multiple forges. TUI repository s
    :caption: Usage
 
    commands
+   agent-integrations
    configuration
    theming
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,6 +44,26 @@ Use full semantic version tags for releases, for example `v2.0.1`.
 yay -S ghgrab-bin
 ```
 
+## Homebrew
+
+A formula ships in this repository for macOS and Linux (Intel and ARM64). It downloads prebuilt release binaries from GitHub.
+
+From a git checkout:
+
+```bash
+brew install --formula Formula/ghgrab.rb
+```
+
+To install a tagged release after cloning:
+
+```bash
+git clone https://github.com/abhixdd/ghgrab.git
+cd ghgrab
+brew install --formula Formula/ghgrab.rb
+```
+
+Submitting to [Homebrew/homebrew-core](https://github.com/Homebrew/homebrew-core) is tracked in [issue #52](https://github.com/abhixdd/ghgrab/issues/52).
+
 ## Verify the install
 
 After installation, confirm the binary is available:


### PR DESCRIPTION
## Summary

- Adds `Formula/ghgrab.rb` for macOS/Linux (Intel + ARM64) using v2.0.1 release binaries with verified SHA256 checksums — addresses [#52](https://github.com/abhixdd/ghgrab/issues/52)
- Adds `docs/agent-integrations.md` documenting production `agent download` consumers, including [Willow 2.0](https://github.com/rudi193-cmd/willow-2.0) SAFE `app_install` (`ghgrab agent download --repo --no-folder`)
- Updates installation docs, README, commands cross-link, and docs index

## Homebrew install (from checkout)

```bash
brew install --formula Formula/ghgrab.rb
```

Submitting to homebrew-core can follow once maintainers are happy with the in-repo formula.

## Test plan

- [ ] `brew install --formula Formula/ghgrab.rb` on macOS or Linux
- [ ] `ghgrab agent tree not-a-url` returns JSON with `"ok":false` (formula test block)
- [ ] Docs render on Read the Docs / local sphinx build

Closes #52 (formula path; core submission is a follow-up).


Made with [Cursor](https://cursor.com)