### PR TITLE
feat: parallel downloads with configurable --jobs flag

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -110,6 +110,7 @@ pub async fn download_paths(
     output_path: Option<String>,
     cwd: bool,
     no_folder: bool,
+    jobs: usize,
 ) -> Result<AgentDownloadResponse> {
     let gh_url = GitHubUrl::parse(url)?;
     let client = GitHubClient::new_for_url(token.clone(), &gh_url)?;
@@ -130,7 +131,7 @@ pub async fn download_paths(
     };
 
     let download_client = GitHubClient::new_for_url(token, &gh_url)?;
-    let downloader = Downloader::new(download_dir.clone(), download_client)?;
+    let downloader = Downloader::new(download_dir.clone(), download_client, jobs)?;
     let errors = downloader
         .download_items(&items_to_download, "", |_| {})
         .await?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ pub struct Cli {
     )]
     token: Option<String>,
 
-    #[arg(long, short = 'j', default_value_t = DEFAULT_JOBS, help = "Number of parallel downloads")]
+    #[arg(long, short = 'j', default_value_t = DEFAULT_JOBS, value_parser = parse_jobs, help = "Number of parallel downloads (1–64)")]
     jobs: usize,
 }
 
@@ -130,7 +130,7 @@ enum AgentCommand {
             help = "One-time GitHub token for this run. Use `auto`/`gh` to read from GitHub CLI"
         )]
         token: Option<String>,
-        #[arg(long, short = 'j', default_value_t = DEFAULT_JOBS, help = "Number of parallel downloads")]
+        #[arg(long, short = 'j', default_value_t = DEFAULT_JOBS, value_parser = parse_jobs, help = "Number of parallel downloads (1–64)")]
         jobs: usize,
         #[arg(long, help = "Print output as JSON (for scripting)")]
         json: bool,
@@ -339,6 +339,17 @@ pub async fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn parse_jobs(s: &str) -> Result<usize, String> {
+    let n: usize = s
+        .parse()
+        .map_err(|_| format!("'{}' is not a valid number", s))?;
+    if !(1..=64).contains(&n) {
+        Err(format!("--jobs must be between 1 and 64 (got {})", n))
+    } else {
+        Ok(n)
+    }
 }
 
 fn resolve_github_token(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use crate::agent::{self, AgentEnvelope};
 use crate::config::Config;
+use crate::download::DEFAULT_JOBS;
 use crate::release::{self, FileTypePreference, ReleaseRequest, ReleaseSelectionCancelled};
 use crate::ui;
 use anyhow::Result;
@@ -29,6 +30,9 @@ pub struct Cli {
         help = "One-time GitHub token (not stored). Use `auto`/`gh` to read from GitHub CLI"
     )]
     token: Option<String>,
+
+    #[arg(long, short = 'j', default_value_t = DEFAULT_JOBS, help = "Number of parallel downloads")]
+    jobs: usize,
 }
 
 #[derive(Subcommand)]
@@ -126,6 +130,10 @@ enum AgentCommand {
             help = "One-time GitHub token for this run. Use `auto`/`gh` to read from GitHub CLI"
         )]
         token: Option<String>,
+        #[arg(long, short = 'j', default_value_t = DEFAULT_JOBS, help = "Number of parallel downloads")]
+        jobs: usize,
+        #[arg(long, help = "Print output as JSON (for scripting)")]
+        json: bool,
     },
 }
 
@@ -219,18 +227,45 @@ pub async fn run() -> Result<()> {
                 no_folder,
                 out,
                 token,
+                jobs,
+                json,
             } => {
                 let token = resolve_github_token(token, default_config.github_token.clone())?;
                 let out = out.or(default_config.download_path.clone());
                 let selected_paths = build_download_request(paths, repo, subtree);
                 let result = match selected_paths {
                     Ok(selected_paths) => {
-                        agent::download_paths(&url, token, &selected_paths, out, cwd, no_folder)
-                            .await
+                        agent::download_paths(
+                            &url,
+                            token,
+                            &selected_paths,
+                            out,
+                            cwd,
+                            no_folder,
+                            jobs,
+                        )
+                        .await
                     }
                     Err(error) => Err(error),
                 };
-                print_agent_json("download", result)?;
+                if json {
+                    print_agent_json("download", result)?;
+                } else {
+                    let data = result?;
+                    if data.errors.is_empty() {
+                        println!(
+                            "Downloaded {} files to {}",
+                            data.downloaded_paths.len(),
+                            data.output_dir
+                        );
+                    } else {
+                        eprintln!("Completed with {} error(s):", data.errors.len());
+                        for err in &data.errors {
+                            eprintln!("  - {}", err);
+                        }
+                        std::process::exit(1);
+                    }
+                }
             }
         },
         Some(Commands::Release {
@@ -291,6 +326,7 @@ pub async fn run() -> Result<()> {
                 download_path,
                 cli.cwd,
                 cli.no_folder,
+                cli.jobs,
                 initial_icon_mode,
             )
             .await?;

--- a/src/download.rs
+++ b/src/download.rs
@@ -11,6 +11,7 @@ pub const DEFAULT_JOBS: usize = 4;
 pub struct Downloader {
     client: GitHubClient,
     base_path: PathBuf,
+    jobs: usize,
     semaphore: Arc<Semaphore>,
 }
 
@@ -20,6 +21,7 @@ impl Downloader {
         Ok(Downloader {
             client,
             base_path,
+            jobs,
             semaphore: Arc::new(Semaphore::new(jobs)),
         })
     }
@@ -29,6 +31,7 @@ impl Downloader {
         Ok(Downloader {
             client: GitHubClient::new(token)?,
             base_path,
+            jobs,
             semaphore: Arc::new(Semaphore::new(jobs)),
         })
     }
@@ -41,29 +44,30 @@ impl Downloader {
     ) -> Result<Vec<String>> {
         let progress_callback = Arc::new(progress_callback);
 
-        let results: Vec<Result<()>> = futures::stream::iter(items.iter().cloned())
+        let nested: Vec<Vec<anyhow::Error>> = futures::stream::iter(items.iter().cloned())
             .map(|item| {
                 let dest_path = self.base_path.join(&item.name);
                 let cb = Arc::clone(&progress_callback);
                 async move {
                     if item.is_file() {
-                        self.download_file(&item, dest_path, cb.as_ref())
-                            .await
-                            .with_context(|| format!("Failed to download {}", item.name))
+                        match self.download_file(&item, dest_path, cb.as_ref()).await {
+                            Ok(()) => vec![],
+                            Err(e) => vec![e.context(format!("Failed to download {}", item.name))],
+                        }
                     } else {
-                        self.download_folder(&item, dest_path, cb.as_ref())
-                            .await
-                            .with_context(|| format!("Failed to download {}", item.name))
+                        self.download_folder(&item, dest_path, cb.as_ref()).await
                     }
                 }
             })
-            .buffer_unordered(usize::MAX)
+            .buffer_unordered(self.jobs)
             .collect()
             .await;
 
-        Ok(results
+        // Errors carry their full anyhow context chain until this single boundary,
+        // where they're rendered to strings for the CLI/agent output.
+        Ok(nested
             .into_iter()
-            .filter_map(|r| r.err())
+            .flatten()
             .map(|e| format!("{:#}", e))
             .collect())
     }
@@ -107,50 +111,55 @@ impl Downloader {
         item: &'a RepoItem,
         dest_path: PathBuf,
         progress_callback: &'a (impl Fn(String) + Send + Sync),
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<anyhow::Error>> + Send + 'a>> {
         Box::pin(async move {
             progress_callback(format!("Scanning folder: {}", item.name));
-            fs::create_dir_all(&dest_path)?;
+
+            if let Err(e) = fs::create_dir_all(&dest_path) {
+                return vec![
+                    anyhow::Error::new(e).context(format!("Failed to create folder {}", item.name))
+                ];
+            }
 
             let contents = {
                 let _permit = Arc::clone(&self.semaphore)
                     .acquire_owned()
                     .await
                     .expect("semaphore closed");
-                self.client.fetch_contents(&item.url).await?
+                match self.client.fetch_contents(&item.url).await {
+                    Ok(contents) => contents,
+                    Err(e) => {
+                        return vec![e.context(format!("Failed to list folder {}", item.name))]
+                    }
+                }
                 // permit released here when _permit drops
             };
 
-            let results: Vec<Result<()>> = futures::stream::iter(contents)
+            let nested: Vec<Vec<anyhow::Error>> = futures::stream::iter(contents)
                 .map(|sub_item| {
                     let sub_dest_path = dest_path.join(&sub_item.name);
                     async move {
                         if sub_item.is_file() {
-                            self.download_file(&sub_item, sub_dest_path, progress_callback)
+                            match self
+                                .download_file(&sub_item, sub_dest_path, progress_callback)
                                 .await
-                                .with_context(|| format!("Failed to download {}", sub_item.name))
+                            {
+                                Ok(()) => vec![],
+                                Err(e) => {
+                                    vec![e.context(format!("Failed to download {}", sub_item.name))]
+                                }
+                            }
                         } else {
                             self.download_folder(&sub_item, sub_dest_path, progress_callback)
                                 .await
-                                .with_context(|| format!("Failed to download {}", sub_item.name))
                         }
                     }
                 })
-                .buffer_unordered(usize::MAX)
+                .buffer_unordered(self.jobs)
                 .collect()
                 .await;
 
-            let errors: Vec<String> = results
-                .into_iter()
-                .filter_map(|r| r.err())
-                .map(|e| format!("{:#}", e))
-                .collect();
-
-            if !errors.is_empty() {
-                return Err(anyhow::anyhow!("{}", errors.join("\n")));
-            }
-
-            Ok(())
+            nested.into_iter().flatten().collect()
         })
     }
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -4,13 +4,14 @@ use futures::StreamExt;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::Semaphore;
 
 pub const DEFAULT_JOBS: usize = 4;
 
 pub struct Downloader {
     client: GitHubClient,
     base_path: PathBuf,
-    jobs: usize,
+    semaphore: Arc<Semaphore>,
 }
 
 impl Downloader {
@@ -19,7 +20,7 @@ impl Downloader {
         Ok(Downloader {
             client,
             base_path,
-            jobs,
+            semaphore: Arc::new(Semaphore::new(jobs)),
         })
     }
 
@@ -28,7 +29,7 @@ impl Downloader {
         Ok(Downloader {
             client: GitHubClient::new(token)?,
             base_path,
-            jobs,
+            semaphore: Arc::new(Semaphore::new(jobs)),
         })
     }
 
@@ -40,24 +41,31 @@ impl Downloader {
     ) -> Result<Vec<String>> {
         let progress_callback = Arc::new(progress_callback);
 
-        let results: Vec<Result<(), String>> = futures::stream::iter(items.iter().cloned())
+        let results: Vec<Result<()>> = futures::stream::iter(items.iter().cloned())
             .map(|item| {
                 let dest_path = self.base_path.join(&item.name);
                 let cb = Arc::clone(&progress_callback);
                 async move {
-                    let result = if item.is_file() {
-                        self.download_file(&item, dest_path, cb.as_ref()).await
+                    if item.is_file() {
+                        self.download_file(&item, dest_path, cb.as_ref())
+                            .await
+                            .with_context(|| format!("Failed to download {}", item.name))
                     } else {
-                        self.download_folder(&item, dest_path, cb.as_ref()).await
-                    };
-                    result.map_err(|e| format!("Failed to download {}: {}", item.name, e))
+                        self.download_folder(&item, dest_path, cb.as_ref())
+                            .await
+                            .with_context(|| format!("Failed to download {}", item.name))
+                    }
                 }
             })
-            .buffer_unordered(self.jobs)
+            .buffer_unordered(usize::MAX)
             .collect()
             .await;
 
-        Ok(results.into_iter().filter_map(|r| r.err()).collect())
+        Ok(results
+            .into_iter()
+            .filter_map(|r| r.err())
+            .map(|e| format!("{:#}", e))
+            .collect())
     }
 
     async fn download_file(
@@ -73,6 +81,11 @@ impl Downloader {
         let lfs_indicator = if item.is_lfs() { " [LFS]" } else { "" };
         progress_callback(format!("Downloading{}: {}", lfs_indicator, item.name));
 
+        let _permit = Arc::clone(&self.semaphore)
+            .acquire_owned()
+            .await
+            .expect("semaphore closed");
+
         let content = self
             .client
             .fetch_bytes(download_url)
@@ -83,7 +96,8 @@ impl Downloader {
             fs::create_dir_all(parent)?;
         }
 
-        fs::write(&dest_path, content).context(format!("Failed to write file: {:?}", dest_path))?;
+        fs::write(&dest_path, content)
+            .with_context(|| format!("Failed to write file: {:?}", dest_path))?;
 
         Ok(())
     }
@@ -96,31 +110,44 @@ impl Downloader {
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
         Box::pin(async move {
             progress_callback(format!("Scanning folder: {}", item.name));
-
             fs::create_dir_all(&dest_path)?;
-            let contents = self.client.fetch_contents(&item.url).await?;
 
-            let results: Vec<Result<(), String>> = futures::stream::iter(contents)
+            let contents = {
+                let _permit = Arc::clone(&self.semaphore)
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore closed");
+                self.client.fetch_contents(&item.url).await?
+                // permit released here when _permit drops
+            };
+
+            let results: Vec<Result<()>> = futures::stream::iter(contents)
                 .map(|sub_item| {
                     let sub_dest_path = dest_path.join(&sub_item.name);
                     async move {
-                        let result = if sub_item.is_file() {
+                        if sub_item.is_file() {
                             self.download_file(&sub_item, sub_dest_path, progress_callback)
                                 .await
+                                .with_context(|| format!("Failed to download {}", sub_item.name))
                         } else {
                             self.download_folder(&sub_item, sub_dest_path, progress_callback)
                                 .await
-                        };
-                        result.map_err(|e| format!("Failed to download {}: {}", sub_item.name, e))
+                                .with_context(|| format!("Failed to download {}", sub_item.name))
+                        }
                     }
                 })
-                .buffer_unordered(self.jobs)
+                .buffer_unordered(usize::MAX)
                 .collect()
                 .await;
 
-            let errors: Vec<String> = results.into_iter().filter_map(|r| r.err()).collect();
-            if let Some(first_error) = errors.into_iter().next() {
-                return Err(anyhow::anyhow!(first_error));
+            let errors: Vec<String> = results
+                .into_iter()
+                .filter_map(|r| r.err())
+                .map(|e| format!("{:#}", e))
+                .collect();
+
+            if !errors.is_empty() {
+                return Err(anyhow::anyhow!("{}", errors.join("\n")));
             }
 
             Ok(())

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,24 +1,34 @@
 use crate::github::{GitHubClient, RepoItem};
 use anyhow::{Context, Result};
+use futures::StreamExt;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
+
+pub const DEFAULT_JOBS: usize = 4;
 
 pub struct Downloader {
     client: GitHubClient,
     base_path: PathBuf,
+    jobs: usize,
 }
 
 impl Downloader {
-    pub fn new(base_path: PathBuf, client: GitHubClient) -> Result<Self> {
+    pub fn new(base_path: PathBuf, client: GitHubClient, jobs: usize) -> Result<Self> {
         fs::create_dir_all(&base_path)?;
-        Ok(Downloader { client, base_path })
+        Ok(Downloader {
+            client,
+            base_path,
+            jobs,
+        })
     }
 
-    pub fn new_github(base_path: PathBuf, token: Option<String>) -> Result<Self> {
+    pub fn new_github(base_path: PathBuf, token: Option<String>, jobs: usize) -> Result<Self> {
         fs::create_dir_all(&base_path)?;
         Ok(Downloader {
             client: GitHubClient::new(token)?,
             base_path,
+            jobs,
         })
     }
 
@@ -28,24 +38,26 @@ impl Downloader {
         _repo_path: &str,
         progress_callback: impl Fn(String) + Send + Sync + 'static,
     ) -> Result<Vec<String>> {
-        let mut errors = Vec::new();
+        let progress_callback = Arc::new(progress_callback);
 
-        for item in items {
-            let dest_path = self.base_path.join(&item.name);
+        let results: Vec<Result<(), String>> = futures::stream::iter(items.iter().cloned())
+            .map(|item| {
+                let dest_path = self.base_path.join(&item.name);
+                let cb = Arc::clone(&progress_callback);
+                async move {
+                    let result = if item.is_file() {
+                        self.download_file(&item, dest_path, cb.as_ref()).await
+                    } else {
+                        self.download_folder(&item, dest_path, cb.as_ref()).await
+                    };
+                    result.map_err(|e| format!("Failed to download {}: {}", item.name, e))
+                }
+            })
+            .buffer_unordered(self.jobs)
+            .collect()
+            .await;
 
-            let result = if item.is_file() {
-                self.download_file(item, dest_path, &progress_callback)
-                    .await
-            } else {
-                self.download_folder(item, dest_path, &progress_callback)
-                    .await
-            };
-
-            if let Err(e) = result {
-                errors.push(format!("Failed to download {}: {}", item.name, e));
-            }
-        }
-        Ok(errors)
+        Ok(results.into_iter().filter_map(|r| r.err()).collect())
     }
 
     async fn download_file(
@@ -88,17 +100,29 @@ impl Downloader {
             fs::create_dir_all(&dest_path)?;
             let contents = self.client.fetch_contents(&item.url).await?;
 
-            for sub_item in contents {
-                let sub_dest_path = dest_path.join(&sub_item.name);
+            let results: Vec<Result<(), String>> = futures::stream::iter(contents)
+                .map(|sub_item| {
+                    let sub_dest_path = dest_path.join(&sub_item.name);
+                    async move {
+                        let result = if sub_item.is_file() {
+                            self.download_file(&sub_item, sub_dest_path, progress_callback)
+                                .await
+                        } else {
+                            self.download_folder(&sub_item, sub_dest_path, progress_callback)
+                                .await
+                        };
+                        result.map_err(|e| format!("Failed to download {}: {}", sub_item.name, e))
+                    }
+                })
+                .buffer_unordered(self.jobs)
+                .collect()
+                .await;
 
-                if sub_item.is_file() {
-                    self.download_file(&sub_item, sub_dest_path, progress_callback)
-                        .await?;
-                } else {
-                    self.download_folder(&sub_item, sub_dest_path, progress_callback)
-                        .await?;
-                }
+            let errors: Vec<String> = results.into_iter().filter_map(|r| r.err()).collect();
+            if let Some(first_error) = errors.into_iter().next() {
+                return Err(anyhow::anyhow!(first_error));
             }
+
             Ok(())
         })
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -118,6 +118,7 @@ pub struct AppState {
     pub folder_sizes: HashMap<String, u64>,
     pub cwd: bool,
     pub no_folder: bool,
+    pub jobs: usize,
     pub is_searching: bool,
     pub search_query: String,
     pub selected_paths: HashSet<String>,
@@ -162,6 +163,7 @@ impl AppState {
             folder_sizes: HashMap::new(),
             cwd: false,
             no_folder: false,
+            jobs: crate::download::DEFAULT_JOBS,
             is_searching: false,
             search_query: String::new(),
             selected_paths: HashSet::new(),
@@ -416,6 +418,7 @@ pub async fn run_tui(
     download_path: Option<String>,
     cwd: bool,
     no_folder: bool,
+    jobs: usize,
     icon_mode: IconMode,
 ) -> Result<IconMode> {
     install_panic_hook();
@@ -432,6 +435,7 @@ pub async fn run_tui(
     state_init.download_path = download_path;
     state_init.cwd = cwd;
     state_init.no_folder = no_folder;
+    state_init.jobs = jobs;
     state_init.icon_mode = icon_mode;
 
     let has_initial_url = initial_url.is_some();
@@ -1271,7 +1275,7 @@ async fn load_repo(state: Arc<Mutex<AppState>>, _client: GitHubClient, mut gh_ur
 
 async fn perform_download(state: Arc<Mutex<AppState>>) -> Result<()> {
     use crate::download::Downloader;
-    let (items_to_download, _repo_path, repo_name, token, custom_path, cwd, no_folder) = {
+    let (items_to_download, _repo_path, repo_name, token, custom_path, cwd, no_folder, jobs) = {
         let s = state.lock().await;
         if let Some(url) = &s.current_url {
             let selected = s.get_selected_items();
@@ -1312,6 +1316,7 @@ async fn perform_download(state: Arc<Mutex<AppState>>) -> Result<()> {
                 s.download_path.clone(),
                 s.cwd,
                 s.no_folder,
+                s.jobs,
             )
         } else {
             return Ok(());
@@ -1342,7 +1347,7 @@ async fn perform_download(state: Arc<Mutex<AppState>>) -> Result<()> {
             .unwrap_or(crate::github::Platform::GitHub)
     };
     let download_client = GitHubClient::new_for_platform(token, platform)?;
-    let downloader = Downloader::new(download_dir.clone(), download_client)?;
+    let downloader = Downloader::new(download_dir.clone(), download_client, jobs)?;
     let state_c = state.clone();
 
     let result = downloader

--- a/tests/agent_cli_test.rs
+++ b/tests/agent_cli_test.rs
@@ -38,6 +38,7 @@ fn agent_download_conflicting_repo_flags_return_json_error() {
         "https://github.com/rust-lang/rust",
         "README.md",
         "--repo",
+        "--json",
     ]);
 
     assert_eq!(payload["api_version"], "1");


### PR DESCRIPTION
## What

- Downloads now run concurrently instead of sequentially.
- Adds a `-j / --jobs` flag to control how many files download in parallel (default: 4).

## Why

- Closes #48 - sequential downloads were slow when a release or repo folder had many files. Each file had to finish before the next one started.

## Benchmark

Downloading the full ghgrab repo (59 files):


<img width="981" height="534" alt="image" src="https://github.com/user-attachments/assets/f58c2223-2720-4428-827a-68ce92874b6c" />

| Mode | Time |
|------|------|
| `-j 1` (sequential) | 23.93s |
| `-j 6` (parallel)   |  4.25s |

**~5.6x faster** with 6 workers.

## Changes

- `src/download.rs` — replaced sequential `for` loop with
  `buffer_unordered(jobs)` for concurrent downloads, both at the
  top-level and inside folder traversal
- `src/cli.rs` — added `-j/--jobs` flag to TUI mode and `agent download`
  subcommand (default: 4)
- `src/agent.rs` / `src/ui/mod.rs` — threaded `jobs` through to the
  `Downloader`

## Notes

- Default of 4 workers avoids hitting GitHub rate limits while still
  giving a significant speedup
- `agent download` now prints human-readable output by default;
  use `--json` to get the original JSON envelope (for scripting)