### PR TITLE
feat: Add MCP Server support and auto-installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +95,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -175,6 +195,18 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "ci_info"
@@ -288,6 +320,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +404,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -566,7 +638,9 @@ dependencies = [
  "ratatui",
  "regex",
  "reqwest",
+ "rmcp",
  "rusty-hook",
+ "schemars",
  "serde",
  "serde_json",
  "syntect",
@@ -707,6 +781,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +884,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1002,6 +1106,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1160,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1161,6 +1280,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1384,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1322,6 +1496,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1561,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1804,7 +2015,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2013,10 +2236,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ tokio = { version = "1.35", features = ["full"] }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+rmcp = { version = "1.7.0", features = ["transport-io"] }
+schemars = "1"
 ratatui = "0.25"
 crossterm = "0.27"
 url = "2.5"

--- a/README.md
+++ b/README.md
@@ -261,6 +261,57 @@ ghgrab agent download https://github.com/rust-lang/rust src/tools --cwd --no-fol
 
 You can pass `--token <TOKEN>` to `agent tree` and `agent download` when an external tool, CI job, or coding agent should authenticate without relying on saved local config.
 
+### MCP (Model Context Protocol) Server
+
+`ghgrab` can act as an MCP server, allowing AI coding assistants (like Cursor, Claude Desktop, VS Code, and Windsurf) to search GitHub repositories, list directories, download folders/files, read file contents, and download release assets directly.
+
+#### Auto-Installation
+
+You can automatically configure `ghgrab` as an MCP server in your favorite AI client by running:
+
+```bash
+ghgrab mcp --install
+```
+
+This interactive command will:
+1. Detect which supported clients are installed on your machine.
+2. Prompt you to select one.
+3. Automatically append the correct `ghgrab mcp` command block to that client's configuration file.
+4. Pass through your saved GitHub token (if set in `ghgrab config`) so the AI client doesn't hit anonymous API rate limits.
+
+#### Manual Configuration
+
+If you prefer to configure it manually, add the following to your client's MCP configuration file (e.g. `claude_desktop_config.json` or `mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "ghgrab": {
+      "command": "ghgrab",
+      "args": ["mcp"],
+      "env": {
+        "GITHUB_TOKEN": "your_github_token_here"
+      }
+    }
+  }
+}
+```
+
+*Note: The `env.GITHUB_TOKEN` block is optional but highly recommended to avoid GitHub API rate limiting.*
+
+#### Exposed Tools
+
+The `ghgrab` MCP server exposes 8 powerful tools to AI assistants:
+
+1. `repo_tree` - Lists all files and directories in a Git repository (supports GitHub, GitLab, Codeberg, Gitea, Forgejo).
+2. `download_files` - Downloads specific files or folders from a repository to the local filesystem.
+3. `download_release` - Downloads a GitHub release asset with OS/arch auto-detection (runs non-interactively).
+4. `search_repos` - Searches GitHub repositories by keyword.
+5. `read_file` - Reads the raw text content of a single file from a repository.
+6. `read_file_preview` - Reads a preview (first N bytes) of a file from a repository (useful for peeking at large files).
+7. `list_releases` - Lists all releases for a GitHub repository.
+8. `repo_info` - Gets repository metadata such as default branch, platform type, and parsed URL components.
+
 ### Configuration
 
 To manage your settings:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,17 @@ enum Commands {
         )]
         token: Option<String>,
     },
+    /// Start an MCP server over stdio, or install ghgrab into an MCP client
+    Mcp {
+        #[arg(long, help = "One-time GitHub token for MCP sessions")]
+        token: Option<String>,
+
+        #[arg(
+            long,
+            help = "Auto-configure ghgrab in an MCP client (Claude Desktop, Cursor, VS Code, Windsurf)"
+        )]
+        install: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -157,16 +168,16 @@ pub async fn run() -> Result<()> {
                     let mut config = Config::load()?;
                     config.github_token = Some(value);
                     config.save()?;
-                    println!("✅ GitHub token saved successfully!");
+                    println!("GitHub token saved successfully!");
                 }
                 SetTarget::Path { value } => {
                     if let Err(e) = Config::validate_path(&value) {
-                        eprintln!("❌ Invalid path: {}", e);
+                        eprintln!("Invalid path: {}", e);
                     } else {
                         let mut config = Config::load()?;
                         config.download_path = Some(value);
                         config.save()?;
-                        println!("✅ Download path saved successfully!");
+                        println!("Download path saved successfully!");
                     }
                 }
             },
@@ -175,13 +186,13 @@ pub async fn run() -> Result<()> {
                     let mut config = Config::load()?;
                     config.github_token = None;
                     config.save()?;
-                    println!("✅ GitHub token removed successfully!");
+                    println!("GitHub token removed successfully!");
                 }
                 UnsetTarget::Path => {
                     let mut config = Config::load()?;
                     config.download_path = None;
                     config.save()?;
-                    println!("✅ Download path removed successfully!");
+                    println!("Download path removed successfully!");
                 }
             },
             ConfigCommand::List => {
@@ -261,6 +272,7 @@ pub async fn run() -> Result<()> {
                 cwd,
                 bin_path,
                 token,
+                allow_prompt: true,
             })
             .await
             {
@@ -277,6 +289,14 @@ pub async fn run() -> Result<()> {
             println!("Saved to: {}", result.download_path);
             if let Some(installed_binary) = result.installed_binary {
                 println!("Installed binary: {}", installed_binary);
+            }
+        }
+        Some(Commands::Mcp { token, install }) => {
+            if install {
+                crate::mcp_install::install_mcp_client(default_config.github_token.clone())?;
+            } else {
+                let token = resolve_github_token(token, default_config.github_token.clone())?;
+                crate::mcp::run_mcp_server(token, default_config.download_path.clone()).await?;
             }
         }
         None => {
@@ -305,7 +325,7 @@ pub async fn run() -> Result<()> {
     Ok(())
 }
 
-fn resolve_github_token(
+pub(crate) fn resolve_github_token(
     cli_token: Option<String>,
     config_token: Option<String>,
 ) -> Result<Option<String>> {
@@ -400,10 +420,10 @@ fn resolve_github_token_from_gh_cli(strict: bool) -> Result<Option<String>> {
     }
 
     if tokens.len() == 1 {
-        eprintln!("🔐 Found token via GitHub CLI.");
+        eprintln!("Found token via GitHub CLI.");
     } else {
         eprintln!(
-            "🔐 Found multiple tokens via GitHub CLI output ({}). Using one token.",
+            "Found multiple tokens via GitHub CLI output ({}). Using one token.",
             tokens.len()
         );
     }

--- a/src/github.rs
+++ b/src/github.rs
@@ -370,7 +370,7 @@ pub struct SearchResult {
     pub items: Vec<SearchItem>,
 }
 
-#[derive(Debug, serde::Deserialize, Clone)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct SearchItem {
     pub full_name: String,
     pub description: Option<String>,
@@ -381,7 +381,7 @@ pub struct SearchItem {
     pub pushed_at: String,
 }
 
-#[derive(Debug, serde::Deserialize, Clone)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct GitHubRelease {
     pub tag_name: String,
     pub draft: bool,
@@ -389,7 +389,7 @@ pub struct GitHubRelease {
     pub assets: Vec<GitHubReleaseAsset>,
 }
 
-#[derive(Debug, serde::Deserialize, Clone)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
 pub struct GitHubReleaseAsset {
     pub name: String,
     pub browser_download_url: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,7 @@ pub mod cli;
 pub mod config;
 pub mod download;
 pub mod github;
+pub mod mcp;
+pub mod mcp_install;
 pub mod release;
 pub mod ui;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,327 @@
+use crate::agent;
+use crate::github::{GitHubClient, GitHubUrl};
+use crate::release;
+use anyhow::Result;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::CallToolResult;
+use rmcp::{tool, tool_router, ServiceExt};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Clone)]
+pub struct GhGrabMcp {
+    pub token: Option<String>,
+    pub download_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct RepoTreeParams {
+    #[doc = "The URL of the repository (e.g. https://github.com/owner/repo)"]
+    url: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct DownloadFilesParams {
+    #[doc = "The URL of the repository (e.g. https://github.com/owner/repo)"]
+    url: String,
+    #[doc = "Specific paths/folders inside the repository to download"]
+    paths: Vec<String>,
+    #[doc = "Optional custom output directory path"]
+    output_dir: Option<String>,
+    #[doc = "If true, downloads directly into the target directory without creating a repo-named folder"]
+    no_folder: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct DownloadReleaseParams {
+    #[doc = "The repository reference (e.g. owner/repo or github.com URL)"]
+    repo: String,
+    #[doc = "Specific release tag name (e.g. v1.0.0). Defaults to the latest release."]
+    tag: Option<String>,
+    #[doc = "OS override (e.g. windows, linux, macos). Defaults to current OS."]
+    os: Option<String>,
+    #[doc = "Architecture override (e.g. x86_64, aarch64). Defaults to current architecture."]
+    arch: Option<String>,
+    #[doc = "If true, extracts archive assets after download. Defaults to true."]
+    extract: Option<bool>,
+    #[doc = "Optional custom regex to match a specific asset name"]
+    asset_regex: Option<String>,
+    #[doc = "Optional custom output directory path"]
+    output_dir: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SearchReposParams {
+    #[doc = "The search query (keyword/term)"]
+    query: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ReadFileParams {
+    #[doc = "The repository URL (e.g. https://github.com/owner/repo)"]
+    url: String,
+    #[doc = "The path to the file within the repository (e.g. src/lib.rs)"]
+    path: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ReadFilePreviewParams {
+    #[doc = "The repository URL (e.g. https://github.com/owner/repo)"]
+    url: String,
+    #[doc = "The path to the file within the repository (e.g. src/lib.rs)"]
+    path: String,
+    #[doc = "Maximum bytes to fetch. Defaults to 8192 (8KB)."]
+    max_bytes: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ListReleasesParams {
+    #[doc = "The owner of the repository"]
+    owner: String,
+    #[doc = "The name of the repository"]
+    repo: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct RepoInfoParams {
+    #[doc = "The URL of the repository (e.g. https://github.com/owner/repo)"]
+    url: String,
+}
+
+#[tool_router(server_handler)]
+impl GhGrabMcp {
+    #[tool(
+        description = "List all files and directories in a Git repository. Supports GitHub, GitLab, Codeberg, Gitea, and Forgejo."
+    )]
+    async fn repo_tree(&self, Parameters(params): Parameters<RepoTreeParams>) -> CallToolResult {
+        match agent::fetch_tree(&params.url, self.token.clone()).await {
+            Ok(res) => CallToolResult::structured(serde_json::to_value(res).unwrap()),
+            Err(e) => CallToolResult::structured_error(serde_json::json!({
+                "error": format!("Failed to fetch repo tree: {}", e)
+            })),
+        }
+    }
+
+    #[tool(
+        description = "Download specific files or folders from a Git repository to the local filesystem."
+    )]
+    async fn download_files(
+        &self,
+        Parameters(params): Parameters<DownloadFilesParams>,
+    ) -> CallToolResult {
+        let output = params.output_dir.or(self.download_path.clone());
+        let no_folder = params.no_folder.unwrap_or(false);
+        match agent::download_paths(
+            &params.url,
+            self.token.clone(),
+            &params.paths,
+            output,
+            false,
+            no_folder,
+        )
+        .await
+        {
+            Ok(res) => CallToolResult::structured(serde_json::to_value(res).unwrap()),
+            Err(e) => CallToolResult::structured_error(serde_json::json!({
+                "error": format!("Failed to download files: {}", e)
+            })),
+        }
+    }
+
+    #[tool(description = "Download a GitHub release asset with OS/arch auto-detection.")]
+    async fn download_release(
+        &self,
+        Parameters(params): Parameters<DownloadReleaseParams>,
+    ) -> CallToolResult {
+        let req = release::ReleaseRequest {
+            repo: params.repo,
+            tag: params.tag,
+            include_prerelease: false,
+            asset_regex: params.asset_regex,
+            os: params.os,
+            arch: params.arch,
+            file_type: release::FileTypePreference::Any,
+            extract: params.extract.unwrap_or(true),
+            output_path: params.output_dir.or(self.download_path.clone()),
+            cwd: false,
+            bin_path: None,
+            token: self.token.clone(),
+            allow_prompt: false, // Ensure non-interactive
+        };
+
+        match release::download_release(req).await {
+            Ok(res) => CallToolResult::structured(serde_json::json!({
+                "owner": res.owner,
+                "repo": res.repo,
+                "tag": res.tag,
+                "asset_name": res.asset_name,
+                "download_path": res.download_path,
+                "installed_binary": res.installed_binary,
+                "extracted": res.extracted
+            })),
+            Err(e) => CallToolResult::structured_error(serde_json::json!({
+                "error": format!("Failed to download release: {}", e)
+            })),
+        }
+    }
+
+    #[tool(description = "Search GitHub repositories by keyword.")]
+    async fn search_repos(
+        &self,
+        Parameters(params): Parameters<SearchReposParams>,
+    ) -> CallToolResult {
+        let client_res = GitHubClient::new(self.token.clone());
+        let client = match client_res {
+            Ok(c) => c,
+            Err(e) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({ "error": e.to_string() }),
+                )
+            }
+        };
+
+        match client.search_repositories(&params.query).await {
+            Ok(repos) => CallToolResult::structured(serde_json::to_value(repos).unwrap()),
+            Err(e) => CallToolResult::structured_error(serde_json::json!({
+                "error": format!("Search failed: {}", e)
+            })),
+        }
+    }
+
+    #[tool(description = "Read the raw text content of a single file from a repository.")]
+    async fn read_file(&self, Parameters(params): Parameters<ReadFileParams>) -> CallToolResult {
+        let gh_url = match GitHubUrl::parse(&params.url) {
+            Ok(url) => url,
+            Err(e) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({ "error": e.to_string() }),
+                )
+            }
+        };
+        let client = match GitHubClient::new_for_url(self.token.clone(), &gh_url) {
+            Ok(c) => c,
+            Err(e) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({ "error": e.to_string() }),
+                )
+            }
+        };
+
+        let raw_url = gh_url.raw_file_url_for_path(&params.path);
+        match client.fetch_raw_content(&raw_url).await {
+            Ok(content) => CallToolResult::structured(serde_json::json!({
+                "path": params.path,
+                "content": content
+            })),
+            Err(e) => CallToolResult::structured_error(serde_json::json!({
+                "error": format!("Failed to read file: {}", e)
+            })),
+        }
+    }
+
+    #[tool(
+        description = "Read a preview (first N bytes) of a file from a repository. Useful for peeking at large files."
+    )]
+    async fn read_file_preview(
+        &self,
+        Parameters(params): Parameters<ReadFilePreviewParams>,
+    ) -> CallToolResult {
+        let gh_url = match GitHubUrl::parse(&params.url) {
+            Ok(url) => url,
+            Err(e) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({ "error": e.to_string() }),
+                )
+            }
+        };
+        let client = match GitHubClient::new_for_url(self.token.clone(), &gh_url) {
+            Ok(c) => c,
+            Err(e) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({ "error": e.to_string() }),
+                )
+            }
+        };
+
+        let raw_url = gh_url.raw_file_url_for_path(&params.path);
+        let max_bytes = params.max_bytes.unwrap_or(8192);
+        match client.fetch_partial_content(&raw_url, max_bytes).await {
+            Ok(content) => CallToolResult::structured(serde_json::json!({
+                "path": params.path,
+                "content": content,
+                "preview_bytes": max_bytes
+            })),
+            Err(e) => CallToolResult::structured_error(serde_json::json!({
+                "error": format!("Failed to preview file: {}", e)
+            })),
+        }
+    }
+
+    #[tool(description = "List all releases for a GitHub repository.")]
+    async fn list_releases(
+        &self,
+        Parameters(params): Parameters<ListReleasesParams>,
+    ) -> CallToolResult {
+        let client = match GitHubClient::new(self.token.clone()) {
+            Ok(c) => c,
+            Err(e) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({ "error": e.to_string() }),
+                )
+            }
+        };
+
+        match client.fetch_releases(&params.owner, &params.repo).await {
+            Ok(releases) => CallToolResult::structured(serde_json::to_value(releases).unwrap()),
+            Err(e) => CallToolResult::structured_error(serde_json::json!({
+                "error": format!("Failed to list releases: {}", e)
+            })),
+        }
+    }
+
+    #[tool(
+        description = "Get repository metadata: default branch, platform type, and parsed URL components."
+    )]
+    async fn repo_info(&self, Parameters(params): Parameters<RepoInfoParams>) -> CallToolResult {
+        let gh_url = match GitHubUrl::parse(&params.url) {
+            Ok(url) => url,
+            Err(e) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({ "error": e.to_string() }),
+                )
+            }
+        };
+        let client = match GitHubClient::new_for_url(self.token.clone(), &gh_url) {
+            Ok(c) => c,
+            Err(e) => {
+                return CallToolResult::structured_error(
+                    serde_json::json!({ "error": e.to_string() }),
+                )
+            }
+        };
+
+        match client.fetch_default_branch(&gh_url).await {
+            Ok(default_branch) => CallToolResult::structured(serde_json::json!({
+                "owner": gh_url.owner,
+                "repo": gh_url.repo,
+                "platform": format!("{:?}", gh_url.platform),
+                "url_branch": gh_url.branch,
+                "url_path": gh_url.path,
+                "default_branch": default_branch
+            })),
+            Err(e) => CallToolResult::structured_error(serde_json::json!({
+                "error": format!("Failed to fetch default branch: {}", e)
+            })),
+        }
+    }
+}
+
+pub async fn run_mcp_server(token: Option<String>, download_path: Option<String>) -> Result<()> {
+    let service = GhGrabMcp {
+        token,
+        download_path,
+    };
+    let server = service.serve(rmcp::transport::stdio()).await?;
+    server.waiting().await?;
+    Ok(())
+}

--- a/src/mcp_install.rs
+++ b/src/mcp_install.rs
@@ -1,0 +1,175 @@
+use anyhow::{anyhow, Context, Result};
+use serde_json::{json, Value};
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+struct ClientInfo {
+    name: &'static str,
+    path: PathBuf,
+    uses_servers_key: bool,
+}
+
+pub fn install_mcp_client(existing_token: Option<String>) -> Result<()> {
+    let home = dirs::home_dir().ok_or_else(|| anyhow!("Could not find home directory"))?;
+    let config_dir =
+        dirs::config_dir().ok_or_else(|| anyhow!("Could not find config directory"))?;
+
+    let clients = [
+        ClientInfo {
+            name: "Claude Desktop",
+            path: config_dir.join("Claude").join("claude_desktop_config.json"),
+            uses_servers_key: false,
+        },
+        ClientInfo {
+            name: "Cursor",
+            path: home.join(".cursor").join("mcp.json"),
+            uses_servers_key: false,
+        },
+        ClientInfo {
+            name: "VS Code (Copilot)",
+            path: home.join(".vscode").join("mcp.json"),
+            uses_servers_key: true,
+        },
+        ClientInfo {
+            name: "Windsurf",
+            path: home
+                .join(".codeium")
+                .join("windsurf")
+                .join("mcp_config.json"),
+            uses_servers_key: false,
+        },
+    ];
+
+    println!("\nDetecting MCP clients...");
+    let mut detected = Vec::new();
+    for (i, client) in clients.iter().enumerate() {
+        let parent = client.path.parent().unwrap();
+        let installed = parent.exists();
+        if installed {
+            detected.push(i);
+            println!(
+                "  {}. [Detected] {} ({})",
+                detected.len(),
+                client.name,
+                client.path.display()
+            );
+        }
+    }
+
+    let choices = if detected.is_empty() {
+        println!("  No MCP client installation folders were auto-detected.");
+        println!("  Listing all supported clients for manual selection:\n");
+        for (i, client) in clients.iter().enumerate() {
+            println!("  {}. {} ({})", i + 1, client.name, client.path.display());
+        }
+        clients
+            .iter()
+            .enumerate()
+            .map(|(i, _)| i)
+            .collect::<Vec<_>>()
+    } else {
+        detected
+    };
+
+    print!("\nSelect a client to configure (or type q to cancel): ");
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    let trimmed = input.trim();
+    if trimmed.eq_ignore_ascii_case("q") {
+        println!("Installation cancelled.");
+        return Ok(());
+    }
+
+    let index = trimmed
+        .parse::<usize>()
+        .map_err(|_| anyhow!("Invalid selection"))?;
+    if index == 0 || index > choices.len() {
+        return Err(anyhow!("Selection out of range"));
+    }
+
+    let selected_client = &clients[choices[index - 1]];
+
+    let exe_path =
+        std::env::current_exe().context("Failed to determine current executable path")?;
+    let exe_str = exe_path
+        .to_str()
+        .ok_or_else(|| anyhow!("Invalid path characters in executable path"))?;
+
+    let mut env_map = serde_json::Map::new();
+    if let Some(tok) = existing_token {
+        env_map.insert("GITHUB_TOKEN".to_string(), Value::String(tok));
+    }
+
+    let server_entry = json!({
+        "command": exe_str,
+        "args": ["mcp"],
+        "env": Value::Object(env_map),
+    });
+
+    if let Some(parent) = selected_client.path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut config: Value = if selected_client.path.exists() {
+        let content = fs::read_to_string(&selected_client.path)?;
+        serde_json::from_str(&content).unwrap_or(json!({}))
+    } else {
+        json!({})
+    };
+
+    let key = if selected_client.uses_servers_key {
+        "servers"
+    } else {
+        "mcpServers"
+    };
+
+    if !config.is_object() {
+        config = json!({});
+    }
+    let config_obj = config.as_object_mut().unwrap();
+    if !config_obj.contains_key(key) {
+        config_obj.insert(key.to_string(), json!({}));
+    }
+
+    let servers_map = config_obj
+        .get_mut(key)
+        .unwrap()
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("Invalid config structure: '{}' key is not an object", key))?;
+
+    if servers_map.contains_key("ghgrab") {
+        print!(
+            "⚠️  ghgrab is already configured in {}. Overwrite? [y/N]: ",
+            selected_client.name
+        );
+        io::stdout().flush()?;
+        let mut confirm = String::new();
+        io::stdin().read_line(&mut confirm)?;
+        let choice = confirm.trim().to_lowercase();
+        if choice != "y" && choice != "yes" {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    servers_map.insert("ghgrab".to_string(), server_entry);
+
+    let pretty_json = serde_json::to_string_pretty(&config)?;
+    fs::write(&selected_client.path, pretty_json)?;
+
+    println!(
+        "\nghgrab MCP server configured successfully in {}!",
+        selected_client.name
+    );
+    println!("   Config updated: {}", selected_client.path.display());
+    println!("   Binary: {}", exe_str);
+    println!(
+        "\n   Please restart {} for changes to take effect.\n",
+        selected_client.name
+    );
+
+    Ok(())
+}

--- a/src/release.rs
+++ b/src/release.rs
@@ -31,6 +31,7 @@ pub struct ReleaseRequest {
     pub cwd: bool,
     pub bin_path: Option<String>,
     pub token: Option<String>,
+    pub allow_prompt: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -74,6 +75,7 @@ pub async fn download_release(request: ReleaseRequest) -> Result<ReleaseDownload
         request.os.as_deref(),
         request.arch.as_deref(),
         request.file_type,
+        request.allow_prompt,
     )?;
 
     let base_dir = resolve_base_dir(request.output_path.clone(), request.cwd)?;
@@ -173,7 +175,7 @@ pub fn select_asset_name_for_request(
     file_type: FileTypePreference,
 ) -> Result<String> {
     Ok(
-        select_asset(assets, repo, asset_regex, os, arch, file_type)?
+        select_asset(assets, repo, asset_regex, os, arch, file_type, true)?
             .name
             .clone(),
     )
@@ -208,6 +210,7 @@ fn select_asset<'a>(
     os: Option<&str>,
     arch: Option<&str>,
     file_type: FileTypePreference,
+    allow_prompt: bool,
 ) -> Result<&'a GitHubReleaseAsset> {
     if assets.is_empty() {
         bail!("The selected release has no downloadable assets");
@@ -245,6 +248,10 @@ fn select_asset<'a>(
 
     if asset_regex.is_some() || has_clear_best_match(&candidates) {
         return Ok(candidates[0].0);
+    }
+
+    if !allow_prompt {
+        bail!("Multiple release assets matched, and interactive selection is disabled. Please specify a more specific asset_regex.");
     }
 
     prompt_for_asset_selection(&candidates)

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -139,7 +139,7 @@ fn test_mcp_repo_info_on_actual_repo() {
             serde_json::from_str(content_text).expect("nested text should be valid JSON");
         assert_eq!(info["owner"], "abhixdd");
         assert_eq!(info["repo"], "ghgrab");
-        assert_eq!(info["platform"], "\"GitHub\"");
+        assert_eq!(info["platform"], "GitHub");
     }
 
     drop(stdin);

--- a/tests/mcp_test.rs
+++ b/tests/mcp_test.rs
@@ -1,0 +1,147 @@
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+
+#[test]
+fn test_mcp_handshake_and_tools_list() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_ghgrab"))
+        .arg("mcp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Failed to spawn ghgrab mcp process");
+
+    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+    let stdout = child.stdout.take().expect("Failed to open stdout");
+    let mut reader = BufReader::new(stdout);
+
+    // 1. Send initialize request
+    let init_req = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}"#;
+    writeln!(stdin, "{}", init_req).expect("Failed to write to stdin");
+    stdin.flush().expect("Failed to flush stdin");
+
+    // Read initialize response
+    let mut init_resp_line = String::new();
+    reader
+        .read_line(&mut init_resp_line)
+        .expect("Failed to read from stdout");
+    let init_resp: Value = serde_json::from_str(&init_resp_line).expect("Invalid JSON response");
+
+    assert_eq!(init_resp["jsonrpc"], "2.0");
+    assert_eq!(init_resp["id"], 1);
+    assert_eq!(init_resp["result"]["protocolVersion"], "2024-11-05");
+    assert_eq!(init_resp["result"]["serverInfo"]["name"], "rmcp");
+
+    // 2. Send initialized notification
+    let initialized_notif = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+    writeln!(stdin, "{}", initialized_notif).expect("Failed to write notification to stdin");
+    stdin.flush().expect("Failed to flush stdin");
+
+    // 3. Send tools/list request
+    let list_req = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#;
+    writeln!(stdin, "{}", list_req).expect("Failed to write tools/list to stdin");
+    stdin.flush().expect("Failed to flush stdin");
+
+    // Read tools/list response
+    let mut list_resp_line = String::new();
+    reader
+        .read_line(&mut list_resp_line)
+        .expect("Failed to read tools/list from stdout");
+    let list_resp: Value = serde_json::from_str(&list_resp_line).expect("Invalid JSON response");
+
+    assert_eq!(list_resp["jsonrpc"], "2.0");
+    assert_eq!(list_resp["id"], 2);
+
+    let tools = list_resp["result"]["tools"]
+        .as_array()
+        .expect("tools should be an array");
+
+    let tool_names: Vec<&str> = tools
+        .iter()
+        .map(|t| t["name"].as_str().expect("tool name should be a string"))
+        .collect();
+
+    assert!(tool_names.contains(&"repo_tree"));
+    assert!(tool_names.contains(&"download_files"));
+    assert!(tool_names.contains(&"download_release"));
+    assert!(tool_names.contains(&"search_repos"));
+    assert!(tool_names.contains(&"read_file"));
+    assert!(tool_names.contains(&"read_file_preview"));
+    assert!(tool_names.contains(&"list_releases"));
+    assert!(tool_names.contains(&"repo_info"));
+
+    // Gracefully shutdown child by dropping stdin
+    drop(stdin);
+    let status = child.wait().expect("Failed to wait on child process");
+    assert!(status.success());
+}
+
+#[test]
+fn test_mcp_repo_info_on_actual_repo() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_ghgrab"))
+        .arg("mcp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("Failed to spawn ghgrab mcp process");
+
+    let mut stdin = child.stdin.take().expect("Failed to open stdin");
+    let stdout = child.stdout.take().expect("Failed to open stdout");
+    let mut reader = BufReader::new(stdout);
+
+    // 1. Send initialize request
+    let init_req = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}"#;
+    writeln!(stdin, "{}", init_req).expect("Failed to write to stdin");
+    stdin.flush().expect("Failed to flush stdin");
+
+    let mut init_resp_line = String::new();
+    reader
+        .read_line(&mut init_resp_line)
+        .expect("Failed to read from stdout");
+
+    // 2. Send initialized notification
+    let initialized_notif = r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#;
+    writeln!(stdin, "{}", initialized_notif).expect("Failed to write notification to stdin");
+    stdin.flush().expect("Failed to flush stdin");
+
+    // 3. Call repo_info tool
+    let call_req = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"repo_info","arguments":{"url":"https://github.com/abhixdd/ghgrab"}}}"#;
+    writeln!(stdin, "{}", call_req).expect("Failed to write tools/call to stdin");
+    stdin.flush().expect("Failed to flush stdin");
+
+    let mut call_resp_line = String::new();
+    reader
+        .read_line(&mut call_resp_line)
+        .expect("Failed to read tools/call from stdout");
+    let call_resp: Value = serde_json::from_str(&call_resp_line).expect("Invalid JSON response");
+
+    assert_eq!(call_resp["jsonrpc"], "2.0");
+    assert_eq!(call_resp["id"], 2);
+
+    println!("Call response: {:?}", call_resp);
+
+    // Assert either structured result or structured error (like rate limiting, auth issues, or offline)
+    let result = &call_resp["result"];
+    if result["isError"].as_bool().unwrap_or(false) {
+        let err_msg = result["content"][0]["text"].as_str().unwrap_or_default();
+        println!(
+            "Info: MCP repo_info call returned structured error (tolerated in test): {}",
+            err_msg
+        );
+    } else {
+        // Successful response structure: MCP CallToolResult structured contains content
+        let content_text = result["content"][0]["text"]
+            .as_str()
+            .expect("text should be present");
+        let info: Value =
+            serde_json::from_str(content_text).expect("nested text should be valid JSON");
+        assert_eq!(info["owner"], "abhixdd");
+        assert_eq!(info["repo"], "ghgrab");
+        assert_eq!(info["platform"], "\"GitHub\"");
+    }
+
+    drop(stdin);
+    let _ = child.wait();
+}


### PR DESCRIPTION
This pull request adds support for running `ghgrab` as an MCP (Model Context Protocol) server, making it possible for AI coding assistants (like Cursor, Claude Desktop, VS Code, and Windsurf) to interact with Git repositories through a standardized protocol. It introduces a new CLI command for MCP, updates documentation, and adds the necessary dependencies and serialization support. Several user-facing messages were also standardized.

Key changes include:

**MCP Server Integration:**

- Added a new `ghgrab mcp` command, allowing the tool to run as an MCP server or auto-install itself into supported AI clients. This enables AI assistants to perform repository operations via a unified protocol. (`src/cli.rs`, `src/mcp.rs`, `src/mcp_install.rs`, `Cargo.toml`, `README.md`) [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR73-R83) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR294-R301) [[3]](diffhunk://#diff-8f7a400d7e288470641e5a946a6ba8ba0ee10262d4d861784c1ae8e747e5ea0cR1-R327) [[4]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R18-R19) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R264-R314) [[6]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R6-R7)

- Implemented eight MCP tools: `repo_tree`, `download_files`, `download_release`, `search_repos`, `read_file`, `read_file_preview`, `list_releases`, and `repo_info`, each exposing repository and file operations to AI clients. (`src/mcp.rs`)

**Dependency and Serialization Updates:**

- Added `rmcp` and `schemars` crates for MCP protocol and JSON schema support. (`Cargo.toml`)
- Enabled `serde::Serialize` for several GitHub data structures to support structured responses in the MCP server. (`src/github.rs`) [[1]](diffhunk://#diff-ef5fd0828e2727ce9e100f72dc4f18f0f126e393d35108269a9bea5e8a104d5cL373-R373) [[2]](diffhunk://#diff-ef5fd0828e2727ce9e100f72dc4f18f0f126e393d35108269a9bea5e8a104d5cL384-R392)

**Documentation:**

- Updated `README.md` with detailed instructions for using and installing the MCP server, including both auto-install and manual configuration steps, and descriptions of the exposed tools.

**CLI and User Experience Improvements:**

- Standardized success and error messages in CLI output for consistency and clarity. (`src/cli.rs`) [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL160-R180) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL178-R195) [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL403-R426)
- Made the `resolve_github_token` function public for use in the new MCP command. (`src/cli.rs`)
- Ensured non-interactive operation for MCP-triggered downloads by setting `allow_prompt: false`. (`src/cli.rs`) [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR275) [[2]](diffhunk://#diff-8f7a400d7e288470641e5a946a6ba8ba0ee10262d4d861784c1ae8e747e5ea0cR1-R327)

These changes significantly expand `ghgrab`'s capabilities, allowing seamless integration with AI tools and improving its usability as both a CLI and a backend service.