### PR TITLE
feat: choose download destination in TUI with Shift+d

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,8 @@ We've kept it pretty standard, but here's a quick cheat sheet:
 | `p` / `P`                         | **Preview** current file                                                 |
 | `a`                               | Select All items                                                         |
 | `u`                               | Unselect all items                                                       |
-| `d` / `D`                         | Download selected items                                                  |
+| `d`                               | Download selected items                                                  |
+| `D`                               | Download selected items to a chosen folder                               |
 | `i`                               | Toggle Icons (Emoji / ASCII)                                             |
 | `g` / `Home`                      | Jump to Top                                                              |
 | `G` / `End`                       | Jump to Bottom                                                           |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -56,7 +56,8 @@ Release downloads are currently GitHub-only.
 | `Backspace` / `h` / `Left` | Go to the previous folder |
 | `/` | Start searching within the current file list |
 | `Space` | Toggle selection |
-| `d` / `D` | Download selected items |
+| `d` | Download selected items |
+| `D` | Download selected items to a chosen folder |
 | `p` / `P` | Preview the current file |
 | `a` | Select all items |
 | `u` | Clear all selections |

--- a/src/ui/components/browser.rs
+++ b/src/ui/components/browser.rs
@@ -325,6 +325,14 @@ pub fn render(f: &mut Frame, area: Rect, state: &BrowserState) {
         Span::styled(" Download", Style::default().fg(BORDER_COLOR())),
         Span::styled("  │  ", Style::default().fg(BORDER_COLOR())),
         Span::styled(
+            "D",
+            Style::default()
+                .fg(SUCCESS_COLOR())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" Save to", Style::default().fg(BORDER_COLOR())),
+        Span::styled("  │  ", Style::default().fg(BORDER_COLOR())),
+        Span::styled(
             "p",
             Style::default()
                 .fg(WARNING_COLOR())

--- a/src/ui/components/dest_prompt.rs
+++ b/src/ui/components/dest_prompt.rs
@@ -1,0 +1,91 @@
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
+};
+
+use crate::ui::theme::*;
+
+pub fn render(f: &mut Frame, area: Rect, input_text: &str, cursor: usize, cursor_visible: bool) {
+    let width = area.width.saturating_sub(4).clamp(20, 72);
+    let height = 4;
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(width),
+            Constraint::Min(0),
+        ])
+        .split(area);
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(height),
+            Constraint::Min(0),
+        ])
+        .split(cols[1]);
+    let prompt_area = rows[1];
+
+    let mut display = input_text.to_string();
+    if cursor_visible {
+        if cursor >= display.chars().count() {
+            display.push('_');
+        } else {
+            let start = display
+                .char_indices()
+                .nth(cursor)
+                .map(|(i, _)| i)
+                .unwrap_or(display.len());
+            let end = display
+                .char_indices()
+                .nth(cursor + 1)
+                .map(|(i, _)| i)
+                .unwrap_or(display.len());
+            display.replace_range(start..end, "_");
+        }
+    }
+
+    // Keep the cursor visible when the path is longer than the box
+    let inner_width = width.saturating_sub(2) as usize;
+    let skip = (cursor + 1).saturating_sub(inner_width);
+    let visible: String = display.chars().skip(skip).take(inner_width).collect();
+
+    let lines = vec![
+        Line::from(Span::styled(visible, Style::default().fg(FG_COLOR()))),
+        Line::from(vec![
+            Span::styled(
+                "Enter",
+                Style::default()
+                    .fg(SUCCESS_COLOR())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" Download", Style::default().fg(BORDER_COLOR())),
+            Span::styled("  │  ", Style::default().fg(BORDER_COLOR())),
+            Span::styled(
+                "Esc",
+                Style::default()
+                    .fg(ERROR_COLOR())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" Cancel", Style::default().fg(BORDER_COLOR())),
+        ]),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Span::styled(
+            " Download to ",
+            Style::default()
+                .fg(SUCCESS_COLOR())
+                .add_modifier(Modifier::BOLD),
+        ))
+        .border_style(Style::default().fg(SUCCESS_COLOR()))
+        .style(Style::default().bg(BG_COLOR()));
+
+    f.render_widget(Clear, prompt_area);
+    f.render_widget(Paragraph::new(lines).block(block), prompt_area);
+}

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod browser;
+pub mod dest_prompt;
 pub mod input;
 pub mod preview;
 pub mod repo_search;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -34,6 +34,7 @@ pub enum AppMode {
     RepositorySearch,
     Browse,
     Preview,
+    DestinationPrompt,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -132,6 +133,8 @@ pub struct AppState {
     pub search_query_version: u64,
     pub search_loading: bool,
     pub search_filters: RepoSearchFilters,
+    pub dest_input: String,
+    pub dest_cursor: usize,
 }
 
 impl Default for AppState {
@@ -177,7 +180,21 @@ impl AppState {
             search_query_version: 0,
             search_loading: false,
             search_filters: RepoSearchFilters::default(),
+            dest_input: String::new(),
+            dest_cursor: 0,
         }
+    }
+
+    pub fn open_dest_prompt(&mut self, prefill: String) {
+        self.dest_cursor = prefill.chars().count();
+        self.dest_input = prefill;
+        self.mode = AppMode::DestinationPrompt;
+    }
+
+    pub fn close_dest_prompt(&mut self) {
+        self.dest_input.clear();
+        self.dest_cursor = 0;
+        self.mode = AppMode::Browse;
     }
 
     pub fn show_toast(&mut self, message: String, type_: ToastType) {
@@ -543,7 +560,7 @@ async fn event_loop(
                         };
                         components::repo_search::render(f, size, &repo_search_state);
                     }
-                    AppMode::Browse => {
+                    AppMode::Browse | AppMode::DestinationPrompt => {
                         let filtered_items = state_lock.get_view_items();
 
                         let browser_state = components::browser::BrowserState {
@@ -559,6 +576,17 @@ async fn event_loop(
                             search_query: &state_lock.search_query,
                         };
                         components::browser::render(f, size, &browser_state);
+
+                        if state_lock.mode == AppMode::DestinationPrompt {
+                            let cursor_visible = (frame_count / 5) % 2 == 0;
+                            components::dest_prompt::render(
+                                f,
+                                size,
+                                &state_lock.dest_input,
+                                state_lock.dest_cursor,
+                                cursor_visible,
+                            );
+                        }
                     }
                     AppMode::Preview => {
                         let s = &mut *state_lock;
@@ -1044,7 +1072,7 @@ async fn handle_input(
                         }
                     }
                 }
-                KeyCode::Char('d') | KeyCode::Char('D') if !s.is_searching => {
+                KeyCode::Char('d') if !s.is_searching => {
                     if s.get_selected_items().is_empty() {
                         s.show_toast("No items selected!".to_string(), ToastType::Info);
                     } else {
@@ -1053,13 +1081,23 @@ async fn handle_input(
 
                         let s_clone = state.clone();
                         tokio::spawn(async move {
-                            if let Err(e) = perform_download(s_clone.clone()).await {
+                            if let Err(e) = perform_download(s_clone.clone(), None).await {
                                 let mut s = s_clone.lock().await;
                                 s.downloading = false;
                                 s.status_message = String::new();
                                 s.show_toast(format!("Download failed: {}", e), ToastType::Error);
                             }
                         });
+                    }
+                }
+                KeyCode::Char('D') if !s.is_searching => {
+                    if s.get_selected_items().is_empty() {
+                        s.show_toast("No items selected!".to_string(), ToastType::Info);
+                    } else {
+                        let prefill = resolve_download_dir(None, s.cwd, s.download_path.as_deref())
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_default();
+                        s.open_dest_prompt(prefill);
                     }
                 }
                 _ => {}
@@ -1073,6 +1111,102 @@ async fn handle_input(
             | KeyCode::Left
             | KeyCode::Char('h') => {
                 s.mode = AppMode::Browse;
+            }
+            _ => {}
+        },
+        AppMode::DestinationPrompt => match key.code {
+            KeyCode::Char('w') | KeyCode::Char('u')
+                if key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                s.dest_input.clear();
+                s.dest_cursor = 0;
+            }
+            KeyCode::Char(c)
+                if !key.modifiers.intersects(
+                    KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER,
+                ) =>
+            {
+                let byte_pos = s
+                    .dest_input
+                    .char_indices()
+                    .nth(s.dest_cursor)
+                    .map(|(i, _)| i)
+                    .unwrap_or(s.dest_input.len());
+                s.dest_input.insert(byte_pos, c);
+                s.dest_cursor += 1;
+            }
+            KeyCode::Backspace => {
+                if s.dest_cursor > 0 {
+                    let byte_pos = s
+                        .dest_input
+                        .char_indices()
+                        .nth(s.dest_cursor - 1)
+                        .map(|(i, _)| i)
+                        .unwrap();
+                    s.dest_input.remove(byte_pos);
+                    s.dest_cursor -= 1;
+                }
+            }
+            KeyCode::Delete => {
+                if s.dest_cursor < s.dest_input.chars().count() {
+                    let byte_pos = s
+                        .dest_input
+                        .char_indices()
+                        .nth(s.dest_cursor)
+                        .map(|(i, _)| i)
+                        .unwrap();
+                    s.dest_input.remove(byte_pos);
+                }
+            }
+            KeyCode::Left if s.dest_cursor > 0 => {
+                s.dest_cursor -= 1;
+            }
+            KeyCode::Right if s.dest_cursor < s.dest_input.chars().count() => {
+                s.dest_cursor += 1;
+            }
+            KeyCode::Left | KeyCode::Right => {}
+            KeyCode::Home => {
+                s.dest_cursor = 0;
+            }
+            KeyCode::End => {
+                s.dest_cursor = s.dest_input.chars().count();
+            }
+            KeyCode::Esc => {
+                s.close_dest_prompt();
+            }
+            KeyCode::Enter => {
+                let dest = s.dest_input.trim().to_string();
+                if dest.is_empty() {
+                    s.show_toast(
+                        "Destination cannot be empty!".to_string(),
+                        ToastType::Warning,
+                    );
+                } else {
+                    match crate::config::Config::validate_path(&dest) {
+                        Err(e) => {
+                            s.show_toast(format!("Invalid destination: {}", e), ToastType::Error);
+                        }
+                        Ok(()) => {
+                            s.close_dest_prompt();
+                            s.downloading = true;
+                            drop(s);
+
+                            let s_clone = state.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = perform_download(s_clone.clone(), Some(dest)).await
+                                {
+                                    let mut s = s_clone.lock().await;
+                                    s.downloading = false;
+                                    s.status_message = String::new();
+                                    s.show_toast(
+                                        format!("Download failed: {}", e),
+                                        ToastType::Error,
+                                    );
+                                }
+                            });
+                        }
+                    }
+                }
             }
             _ => {}
         },
@@ -1273,7 +1407,31 @@ async fn load_repo(state: Arc<Mutex<AppState>>, _client: GitHubClient, mut gh_ur
     }
 }
 
-async fn perform_download(state: Arc<Mutex<AppState>>) -> Result<()> {
+/// Resolves the base download directory. Priority: explicit destination
+/// (from the `D` prompt) > `--cwd` > configured path > user Downloads folder.
+pub fn resolve_download_dir(
+    dest_override: Option<&str>,
+    cwd: bool,
+    custom_path: Option<&str>,
+) -> Result<std::path::PathBuf> {
+    if let Some(dest) = dest_override {
+        return Ok(std::path::PathBuf::from(dest));
+    }
+    if cwd {
+        return std::env::current_dir().context("Could not get current working directory");
+    }
+    if let Some(path) = custom_path {
+        return Ok(std::path::PathBuf::from(path));
+    }
+    dirs::download_dir()
+        .or_else(|| dirs::home_dir().map(|h| h.join("Downloads")))
+        .context("Could not find User Downloads directory")
+}
+
+async fn perform_download(
+    state: Arc<Mutex<AppState>>,
+    dest_override: Option<String>,
+) -> Result<()> {
     use crate::download::Downloader;
     let (items_to_download, _repo_path, repo_name, token, custom_path, cwd, no_folder, jobs) = {
         let s = state.lock().await;
@@ -1323,15 +1481,7 @@ async fn perform_download(state: Arc<Mutex<AppState>>) -> Result<()> {
         }
     };
 
-    let download_dir = if cwd {
-        std::env::current_dir().context("Could not get current working directory")?
-    } else if let Some(path) = custom_path {
-        std::path::PathBuf::from(path)
-    } else {
-        dirs::download_dir()
-            .or_else(|| dirs::home_dir().map(|h| h.join("Downloads")))
-            .context("Could not find User Downloads directory")?
-    };
+    let download_dir = resolve_download_dir(dest_override.as_deref(), cwd, custom_path.as_deref())?;
 
     let download_dir = if no_folder {
         download_dir

--- a/tests/app_state_test.rs
+++ b/tests/app_state_test.rs
@@ -461,6 +461,49 @@ fn test_repo_search_sort_modes() {
 }
 
 #[test]
+fn test_dest_prompt_open_and_close() {
+    use ghgrab::ui::AppMode;
+    let mut state = AppState::new();
+    state.mode = AppMode::Browse;
+
+    state.open_dest_prompt("/tmp/downloads".to_string());
+    assert_eq!(state.mode, AppMode::DestinationPrompt);
+    assert_eq!(state.dest_input, "/tmp/downloads");
+    assert_eq!(state.dest_cursor, "/tmp/downloads".chars().count());
+
+    state.close_dest_prompt();
+    assert_eq!(state.mode, AppMode::Browse);
+    assert!(state.dest_input.is_empty());
+    assert_eq!(state.dest_cursor, 0);
+}
+
+#[test]
+fn test_dest_prompt_unicode_prefill_cursor() {
+    let mut state = AppState::new();
+    state.open_dest_prompt("cartella-università".to_string());
+    // Cursor is measured in chars, not bytes
+    assert_eq!(state.dest_cursor, "cartella-università".chars().count());
+}
+
+#[test]
+fn test_resolve_download_dir_priority() {
+    use ghgrab::ui::resolve_download_dir;
+    use std::path::PathBuf;
+
+    // Explicit destination wins over everything
+    let dir = resolve_download_dir(Some("/explicit/dest"), true, Some("/configured")).unwrap();
+    assert_eq!(dir, PathBuf::from("/explicit/dest"));
+
+    // --cwd wins over the configured path
+    let dir = resolve_download_dir(None, true, Some("/configured")).unwrap();
+    assert_eq!(dir, std::env::current_dir().unwrap());
+
+    // Configured path is used when no override or --cwd is present
+    let dir = resolve_download_dir(None, false, Some("/configured")).unwrap();
+    assert_eq!(dir, PathBuf::from("/configured"));
+}
+
+#[test]
 fn test_cancel_repo_search_invalidates_pending_results() {
     let mut state = AppState::new();
     state.search_query_version = 5;


### PR DESCRIPTION
## What

Adds an interactive destination prompt to the TUI. Pressing `D` (Shift+d) in the file browser opens a "Download to" prompt prefilled with the current default download directory. `Enter` validates the path and downloads the selected items there (for that run only — nothing is saved to config); `Esc` cancels. The lowercase `d` shortcut keeps its current behavior.

## Why

Right now changing the download destination requires quitting the TUI and re-running with `--cwd`, or changing `ghgrab config set path`. This makes one-off downloads to a specific folder much quicker without touching the saved config.

## Notes

- New `AppMode::DestinationPrompt` plus a small `dest_prompt` overlay component, following the existing toast/search-bar patterns.
- Path input is unicode-safe (same handling as the home URL input) and reuses `Config::validate_path`.
- Directory resolution extracted into `resolve_download_dir` with priority: prompt > `--cwd` > configured path > Downloads folder. `--no-folder` behaves as before.
- Tests added for the prompt state and the resolution priority; README, quickstart docs, and the TUI help bar updated.

