### PR TITLE
docs: Add x eget installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ cargo install ghgrab
 pipx install ghgrab
 ```
 
+### X-CMD
+
+Alternatively, install it with [x-cmd](https://www.x-cmd.com/mod/eget), which downloads the pre-built binary from GitHub Releases:
+
+```bash
+x eget use abhixdd/ghgrab
+```
+
 ### Nix
 
 To have the latest commit:


### PR DESCRIPTION
Add `x eget` as an installation method for ghgrab.

`x eget` allows users to install ghgrab by downloading its pre-built binary directly from the project's GitHub Releases:

```sh
x eget use abhixdd/ghgrab
```